### PR TITLE
Refactor css cdn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,6 @@ jobs:
           git add dubplus.css
           git commit -m "[auto]: Update dubplus.js with branch name"
           git push
+
+      - name: Purge jsDelivr cache
+        run: npm run purge-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.1.2] - TBD
 
+This version does not affect the extensions so we do not need to release new versions of them for Chrome and FireFox.
+
+### Fixed
+
+Refactored how we selected which CSS file to load from the CDN when using Dub+ from a bookmarklet. Now it tries to match the same version as the dubplus.js.
+
 ### Other
 
-Internal tooling and build process related changes. See this PR: https://github.com/DubPlus/DubPlus/pull/161
+Internal tooling and build process related changes.
 
 ## [4.1.1] - 2025-08-29
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
 import './dubplus.css';
 import { mount, unmount } from 'svelte';
 import DubPlus from './DubPlus.svelte';
-import { link } from './utils/css';
-import { logError, logInfo } from './utils/logger';
+import { loadDubPlusCSSforBookmarklet } from './utils/css';
+import { logInfo } from './utils/logger';
 
 const loadedAsExtension = 'dubplusExtensionLoaded' in window;
 
@@ -10,9 +10,7 @@ logInfo('loaded as extension:', loadedAsExtension);
 
 // We only load the CSS when Dub+ is loaded from a bookmarklet.
 if (!import.meta.env.DEV && !loadedAsExtension) {
-  link('/dubplus.css', 'dubplus-css').catch((e) => {
-    logError('Failed to load dubplus.css', e);
-  });
+  loadDubPlusCSSforBookmarklet();
 }
 
 let container = document.getElementById('dubplus-container');

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -1,4 +1,5 @@
 import pkg from '../../package.json';
+import { logError } from './logger';
 const CDN_ROOT = '//cdn.jsdelivr.net/gh/DubPlus';
 
 /**
@@ -16,27 +17,19 @@ const makeLink = function (className, fileName) {
 };
 
 /**
- * Loads a CSS file into <head>.
- *
- * @example css.load("/options/show_timestamps.css", "show_timestamps_link");
- *
  * @param {string} cssFile    the css file location
  * @param {string} className  class name for element
+ * @param {string} specificVersion indicates a specific version to load
  * @returns {Promise<void>}
  */
-export function link(cssFile, className) {
+export function link(cssFile, className, specificVersion = '') {
   cssFile = cssFile.replace(/^\//, ''); // remove leading slash
   return new Promise((resolve, reject) => {
     document.querySelector(`link.${className}`)?.remove();
     const cacheBuster = import.meta.env.DEV ? Date.now() : pkg.version;
     let cdnPath = 'DubPlus';
-    const branch = import.meta.env.VITE_GIT_BRANCH?.trim();
-    if (branch) {
-      if (branch === 'main' || branch === 'master') {
-        cdnPath += '@latest';
-      } else {
-        cdnPath += `@${branch}`;
-      }
+    if (specificVersion) {
+      cdnPath += `@${specificVersion}`;
     }
     const link = makeLink(
       className,
@@ -63,4 +56,31 @@ export function style(cssFile, id) {
       style.textContent = css;
       document.head.appendChild(style);
     });
+}
+
+export async function loadDubPlusCSSforBookmarklet() {
+  let version = '';
+  const branch = import.meta.env.VITE_GIT_BRANCH?.trim();
+  if (branch && branch !== 'main' && branch !== 'master') {
+    // use branch name as version so that we can test develop, beta, etc.
+    version = branch;
+  } else if (!branch || branch === 'main' || branch === 'master') {
+    // We first try and load the matching release version
+    version = pkg.version;
+  }
+
+  try {
+    await link('/dubplus.css', 'dubplus-css', version);
+    // if this worked then we can stop here
+    return;
+  } catch (e) {
+    logError(`Failed to load dubplus.css at version @${version}`, e);
+  }
+
+  // if we are here then we failed to load the specific version, so try latest
+  try {
+    await link('/dubplus.css', 'dubplus-css', 'latest');
+  } catch (e) {
+    logError('Failed to load dubplus.css', e);
+  }
 }

--- a/tasks/git-branch.js
+++ b/tasks/git-branch.js
@@ -16,8 +16,7 @@ export function branchName() {
 
 export function getCurrentBranch() {
   try {
-    const name = branchName();
-    return name;
+    return branchName() || '';
   } catch {
     return '';
   }


### PR DESCRIPTION
I updated how we are choosing which CSS file to load from the CDN when using Dub+ from a bookmarklet. Now it tries to grab the same version as the dubplus.js using the version listed in the package.json file. Or if it's in a branch like develop or beta, it will try those first.

Also updated the purge cache script and restored it in the build.yml